### PR TITLE
Small improvements + better Django 1.9 support

### DIFF
--- a/adyen/__init__.py
+++ b/adyen/__init__.py
@@ -13,9 +13,11 @@ try:
 except ImportError:
     from io import StringIO
 import sys
-from urllib import urlencode
-from urlparse import urlparse, parse_qs
-
+try:
+    from urllib import urlencode
+    from urlparse import urlparse, parse_qs
+except ImportError:
+    from urllib.parse import urlencode, urlparse, parse_qs
 import pytz
 
 log = logging.getLogger(__name__)

--- a/adyen/__init__.py
+++ b/adyen/__init__.py
@@ -67,6 +67,7 @@ class HostedPayment(object):
                  currency_code, is_live=False, **kwargs):
         self.backend = backend
         self.merchant_reference = merchant_reference
+        self.merchant_order_reference = None
         self.payment_amount = payment_amount
         self.currency_code = currency_code
         self.ship_before_date = timedelta(days=3)
@@ -116,6 +117,7 @@ class HostedPayment(object):
         optional_params = {
             'shopperLocale': self.shopper_locale,
             'orderData': self._encode_order_data(self.order_data),
+            'merchantOrderReference': self.merchant_order_reference,
             'merchantReturnData': self.merchant_return_data,
             'countryCode': self.country_code,
             'shopperEmail': self.shopper_email,

--- a/adyen/__init__.py
+++ b/adyen/__init__.py
@@ -27,6 +27,10 @@ DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 if sys.version_info[0] >= 3:
     unicode = str
 
+try:
+    t = StandardError
+except NameError:
+    StandardError = Exception
 
 class UnknownSkinCode(StandardError):
     pass

--- a/adyen/__init__.py
+++ b/adyen/__init__.py
@@ -8,7 +8,10 @@ import gzip
 import hashlib
 import hmac
 import logging
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import sys
 from urllib import urlencode
 from urlparse import urlparse, parse_qs
@@ -203,7 +206,7 @@ class HostedPayment(object):
         if not value:
             return None
 
-        out = StringIO.StringIO()
+        out = StringIO()
         with gzip.GzipFile(fileobj=out, mode="w") as f:
             f.write(value)
         return out.getvalue().encode('base64')

--- a/adyen/api.py
+++ b/adyen/api.py
@@ -33,8 +33,11 @@ u'mockreference'
 
 from __future__ import unicode_literals
 
-from urllib import urlencode
-from urlparse import urlparse, parse_qs
+try:
+    from urllib import urlencode
+    from urlparse import urlparse, parse_qs
+except ImportError:
+    from urllib.parse import urlencode, urlparse, parse_qs
 
 from adyen import (HostedPayment, HostedPaymentResult, _get_result_signature,
                    HostedPaymentNotification)

--- a/django_adyen/__init__.py
+++ b/django_adyen/__init__.py
@@ -1,16 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
-from django.conf.urls import url
-
-from . import views
-
-urlpatterns = [
-    url(r'^payment-done/$', views.PaymentResultView.as_view(),
-        name='payment-result'),
-    url(r'^notify/$', views.NotificationView.as_view(),
-        name='payment-notification')
-]
-
-urls = urlpatterns, 'django-adyen', 'django-adyen'
+urls = ('django_adyen.urls', 'django-adyen', 'django-adyen')

--- a/django_adyen/api.py
+++ b/django_adyen/api.py
@@ -37,7 +37,7 @@ def create_payment(order_number, *args, **kwargs):
 def pay(payment, build_absolute_uri=None, force_multi=False):
     if not payment.res_url:
         if not build_absolute_uri:
-            raise StandardError("Pass build_absolute_uri if you don't set "
+            raise Exception("Pass build_absolute_uri if you don't set "
                                 "res_url on the payment yourself.")
 
         payment.res_url = build_absolute_uri(

--- a/django_adyen/api.py
+++ b/django_adyen/api.py
@@ -12,6 +12,9 @@ from .models import Payment, Result, Notification
 
 
 def create_payment(order_number, *args, **kwargs):
+    # API Manual, page 8: reference:
+    # If you need to provide multiple references for a transaction you may
+    # use this field to submit them with the transaction, separating each with "-".
     merchant_reference = ("{order_number}-{{payment_id}}"
                           .format(order_number=order_number))
 
@@ -20,6 +23,8 @@ def create_payment(order_number, *args, **kwargs):
 
     if not payment:
         return
+
+    payment.merchant_order_reference = order_number  # The reference to link multiple transactions to each other.
 
     if hasattr(settings, 'ADYEN_COUNTRY_CODE'):
         payment.country_code = settings.ADYEN_COUNTRY_CODE

--- a/django_adyen/models.py
+++ b/django_adyen/models.py
@@ -226,12 +226,12 @@ class Notification(models.Model):
 
     @property
     def order_number(self):
-        return self.merchant_reference.split('-')[0]
+        return self.merchant_reference.rsplit('-', 1)[0]
 
     @property
     def payment(self):
         try:
-            payment_id = int(self.merchant_reference.split('-')[1])
+            payment_id = int(self.merchant_reference.rsplit('-', 1)[1])
         except ValueError:
             raise ValueError("merchant_reference '{}' of notification '{}'"
                              " doesn't have format"

--- a/django_adyen/models.py
+++ b/django_adyen/models.py
@@ -177,6 +177,11 @@ class NotificationManager(models.Manager):
 
 
 class Notification(models.Model):
+    """
+    All received notifications from Adyen are stored in the database.
+    These are processed by a task, which updates the :attr:`handled` field.
+    """
+    # Possible event codes:
     AUTHORISATION = 'AUTHORISATION'
     CANCELLATION = 'CANCELLATION'
     REFUND = 'REFUND'
@@ -207,6 +212,7 @@ class Notification(models.Model):
     success = models.BooleanField(default=None)
     # see Payment.brand_code, which is the same
     payment_method = models.CharField(max_length=40, blank=True, null=True)
+    # The possible operations (e.g. "REFUND" or "CANCEL,CAPTURE,REFUND")
     operations = models.TextField()
     reason = models.TextField()
     value = models.IntegerField(null=True)
@@ -226,6 +232,11 @@ class Notification(models.Model):
 
     @property
     def order_number(self):
+        """
+        Extract the order number from the merchant_reference.
+
+        Adyen supports adding "{order_number}-{id}"
+        """
         return self.merchant_reference.rsplit('-', 1)[0]
 
     @property

--- a/django_adyen/urls.py
+++ b/django_adyen/urls.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url(r'^payment-done/$', views.PaymentResultView.as_view(),
+        name='payment-result'),
+    url(r'^notify/$', views.NotificationView.as_view(),
+        name='payment-notification')
+]

--- a/oscar_adyen/__init__.py
+++ b/oscar_adyen/__init__.py
@@ -1,16 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
-from django.conf.urls import url
-
-from django_adyen import urlpatterns
-
-urlpatterns = [
-    url(r'^payment-done/(?P<basket_id>\d+)/$',
-        'oscar_adyen.views.payment_result', name='payment-result')
-] + urlpatterns
-
-urls = urlpatterns, 'oscar-adyen', 'oscar-adyen'
+urls = 'oscar_adyen.urls', 'oscar-adyen', 'oscar-adyen'
 
 default_app_config = ('oscar_adyen.apps.OscarAdyenConfig')

--- a/oscar_adyen/api.py
+++ b/oscar_adyen/api.py
@@ -35,7 +35,7 @@ PAYMENT_METHOD_NAMES = {
 }
 
 
-class PaymentFailed(StandardError):
+class PaymentFailed(Exception):
     pass
 
 

--- a/oscar_adyen/api.py
+++ b/oscar_adyen/api.py
@@ -96,11 +96,17 @@ get_unhandled_notifications = django_adyen_api.get_unhandled_notifications
 
 
 def handle_notifications():
+    """
+    Process all unhandled notifications
+    """
     return len(filter(None, map(handle_notification,
                                 get_unhandled_notifications())))
 
 
 def handle_notification(notification):
+    """
+    Process a notification
+    """
     log.info('Processing adyen notification {}'.format(notification))
 
     try:

--- a/oscar_adyen/urls.py
+++ b/oscar_adyen/urls.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.conf.urls import url
+
+from django_adyen import urlpatterns
+
+urlpatterns = [
+    url(r'^payment-done/(?P<basket_id>\d+)/$',
+        'oscar_adyen.views.payment_result', name='payment-result')
+] + urlpatterns


### PR DESCRIPTION
This pull request offers a few fixes for this library:
- Allow order numbers with dashes
- a clearer usage of unicode in the hmac code.
- Added merchantOrderReference parameter, as the Adyen docs prescribe.
- Fixed url layout for Django 1.9, there is no longer an import in `__init__.py` while remaining fully compatible.
- Updated some docstrings.

Feel free to cherry-pick if you like, each feature is nicely defined in a separate commit.
